### PR TITLE
initialize repo

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,71 @@
+env:
+  APP_NAME: ${BUILDKITE_PIPELINE_SLUG}
+  SONAR_HOST: "https://sonarcloud.io"
+
+steps:
+- group: ":test_tube: Tests"
+  key: "tests"
+  steps:
+  - label: ":golangci-lint: lint :lint-roller:"
+    key: "lint"
+    plugins:
+      - docker#v5.10.0:
+          image: "registry.hub.docker.com/golangci/golangci-lint:v1.55.2"
+          command: ["golangci-lint", "run", "-v", "--timeout", "10m"]
+          environment: 
+            - "GOTOOLCHAIN=auto"
+  - label: ":golang: go test"
+    key: "go_test"
+    plugins:
+      - docker#v5.10.0:
+          image: golang:1.22.1
+          command: ["go", "test", "-coverprofile=coverage.out","./..."]
+    artifact_paths: ["coverage.out"]
+  
+- group: ":closed_lock_with_key: Security Checks"
+  depends_on: "tests"
+  key: "security"
+  steps:
+  - label: ":closed_lock_with_key: gosec"
+    key: "gosec"
+    plugins:
+      - docker#v5.10.0:
+          image: "registry.hub.docker.com/securego/gosec:2.18.2"
+          command: ["-no-fail", "-exclude-generated", "-fmt sonarqube", "-out", "results.txt", "./..."]
+          environment:
+            - "GOTOOLCHAIN=auto"
+    artifact_paths: ["results.txt"]
+
+  - label: ":github: upload PR reports"
+    key: "scan-upload-pr"
+    if: build.pull_request.id != null
+    depends_on: ["gosec", "go_test"]
+    plugins:
+      - artifacts#v1.9.3:
+          download: "results.txt"
+      - artifacts#v1.9.3:
+          download: "coverage.out"
+          step: "go_test"    
+      - docker#v5.10.0:
+            image: "sonarsource/sonar-scanner-cli:5"
+            environment:
+              - "SONAR_TOKEN"
+              - "SONAR_HOST_URL=$SONAR_HOST"
+              - "SONAR_SCANNER_OPTS=-Dsonar.pullrequest.branch=$BUILDKITE_BRANCH -Dsonar.pullrequest.base=$BUILDKITE_PULL_REQUEST_BASE_BRANCH -Dsonar.pullrequest.key=$BUILDKITE_PULL_REQUEST"
+
+  - label: ":github: upload reports"
+    key: "scan-upload"
+    if: build.branch == "main"
+    depends_on: ["gosec", "go_test"]
+    plugins:
+      - artifacts#v1.9.3:
+          download: results.txt
+      - artifacts#v1.9.3:
+          download: coverage.out
+          step: "go_test"
+      - docker#v5.10.0:
+            image: "sonarsource/sonar-scanner-cli:5"
+            environment:
+              - "SONAR_TOKEN"
+              - "SONAR_HOST_URL=$SONAR_HOST"
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @datumforge/blacksmiths

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,21 @@
+exclude:
+  labels:
+    - ignore-for-release
+  authors:
+    - octocat
+    - github-actions
+categories:
+  - title: Breaking Changes 🛠
+    labels:
+      - Semver-Major
+      - breaking-change
+  - title: New Features 🎉
+    labels:
+      - Semver-Minor
+      - enhancement
+  - title: 👒 Dependencies
+    labels:
+      - dependencies
+  - title: Other Changes
+    labels:
+      - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,46 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
 # Go workspace file
 go.work
+
+# local dev created files
+*.db
+
+server.crt 
+server.key 
+private_key.pem
+public_key.pem
+
+# Packages
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+
+# Logs 
+*.log
+
+# Editor files
+.vscode
+
+# OS Generated Files
+.DS_Store*
+.AppleDouble
+.LSOverride
+ehthumbs.db
+Icon?
+Thumbs.db
+
+.scannerwork/**
+results.txt
+
+*.mime
+*.mim
+
+# Configs
+*.env
+*.env-dev

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,65 @@
+linters-settings:
+  goimports:
+    local-prefixes: github.com/datumforge/go-turso
+  gofumpt:
+    extra-rules: true
+  gosec:
+    exclude-generated: true
+  revive:
+    ignore-generated-header: true
+
+run:
+  skip-files:
+    - mockery
+
+linters:
+  enable:
+    # default linters
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+    - gosec
+    - bodyclose
+    - noctx
+
+    # additional linters
+    - gocritic
+    - gocyclo
+    - goerr113
+    - gofmt
+    - goimports
+    - gomnd
+    - govet
+    - misspell
+    - revive
+    - stylecheck
+    - whitespace
+    - wsl
+issues:
+  exclude:
+    # Default excludes from `golangci-lint run --help` with EXC0002 removed
+    # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+    # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
+    # - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
+    # EXC0003 golint: False positive when tests are defined in package 'test'
+    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
+    # EXC0004 govet: Common false positives
+    - (possible misuse of unsafe.Pointer|should have signature)
+    # EXC0005 staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
+    - ineffective break statement. Did you mean to break out of the outer loop
+    # EXC0006 gosec: Too many false-positives on 'unsafe' usage
+    - Use of unsafe calls should be audited
+    # EXC0007 gosec: Too many false-positives for parametrized shell calls
+    - Subprocess launch(ed with variable|ing should be audited)
+    # EXC0008 gosec: Duplicated errcheck checks
+    - (G104|G307)
+    # EXC0009 gosec: Too many issues in popular repos
+    - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+    # EXC0010 gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
+    - Potential file inclusion via variable
+  exclude-use-default: false

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Datum Technology, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,120 @@
+[![Build status](https://badge.buildkite.com/98081178d65983e047299f1eaabeaf336cefc5db496500332c.svg)](https://buildkite.com/datum/go-turso)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=datumforge_go-turso&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=datumforge_go-turso)
+
+# Go-Turso
+
+Golang client for interacting with the Turso Platform API. 
+
+## Usage
+
+```
+go get /github.com/datumforge/go-turso@latest
+```
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/datumforge/go-turso"
+)
+
+func main() {
+	// setup the configuration
+	apiToken := os.Getenv("TURSO_API_TOKEN")
+	config := turso.Config{
+		Token:   apiToken,
+		BaseURL: "https://api.turso.tech",
+		OrgName: "datum",
+	}
+
+	// create the Turso Client
+	tc, err := turso.NewClient(config)
+	if err != nil {
+		log.Fatalf("failed to initialize turso client", "error", err)
+	}
+
+	// List All Groups
+	groups, err := tc.Group.ListGroups(context.Background())
+	if err != nil {
+		fmt.Println("error listing groups:", err)
+
+		return
+	}
+
+	for _, group := range groups.Groups {
+		fmt.Println("Group:", group.Name)
+	}
+
+	// List All Databases
+	databases, err := tc.Database.ListDatabases(context.Background())
+	if err != nil {
+		fmt.Println("error listing databases:", err)
+
+		return
+	}
+
+	for _, database := range databases.Databases {
+		fmt.Println("Database:", database.Name)
+	}
+
+	// List All Organizations
+	orgs, err := tc.Organization.ListOrganizations(context.Background())
+	if err != nil {
+		fmt.Println("error listing organizations:", err)
+
+		return
+	}
+
+	for _, org := range *orgs {
+		fmt.Println("Organization:", org.Name, org.Slug)
+	}
+
+	// Create a new Group
+	g := turso.GroupCreateRequest{
+		Name:     "test-group",
+		Location: "ord",
+	}
+    
+	group, err := tc.Group.CreateGroup(context.Background(), g)
+	if err != nil {
+		fmt.Println("error creating group:", err)
+	}
+
+	fmt.Println("Group Created:", group.Group.Name, group.Group.Locations)
+
+	// Delete the Group
+	deletedGroup, err := tc.Group.DeleteGroup(context.Background(), g.Name)
+	if err != nil {
+		fmt.Println("error deleting group:", err)
+	}
+
+	fmt.Println("Group Deleted:", deletedGroup.Group.Name, deletedGroup.Group.Locations)
+
+	// Create a new Database
+	d := turso.CreateDatabaseRequest{
+		Group:    "default",
+		IsSchema: false,
+		Name:     "test-database",
+	}
+
+	database, err := tc.Database.CreateDatabase(context.Background(), d)
+	if err != nil {
+		fmt.Println("error creating database:", err)
+	}
+
+	fmt.Println("Database Created:", database.Database.Name)
+
+	// Delete the Database
+	deletedDatabase, err := tc.Database.DeleteDatabase(context.Background(), d.Name)
+	if err != nil {
+		fmt.Println("error deleting database:", err)
+	}
+
+	fmt.Println("Database Deleted:", deletedDatabase.Database)
+}
+```

--- a/README.md
+++ b/README.md
@@ -5,10 +5,16 @@
 
 Golang client for interacting with the Turso Platform API. 
 
+Currently supports the following endpoints:
+1. `Organizations`: `List`
+1. `Groups`: `List`, `Get`, `Create`, `Delete`
+1. `Databases`: `List`, `Get`, `Create`, `Delete`
+1. `Database Tokens`: `Create`
+
 ## Usage
 
 ```
-go get /github.com/datumforge/go-turso@latest
+go get github.com/datumforge/go-turso
 ```
 
 ```go
@@ -79,7 +85,7 @@ func main() {
 		Name:     "test-group",
 		Location: "ord",
 	}
-    
+
 	group, err := tc.Group.CreateGroup(context.Background(), g)
 	if err != nil {
 		fmt.Println("error creating group:", err)
@@ -118,3 +124,7 @@ func main() {
 	fmt.Println("Database Deleted:", deletedDatabase.Database)
 }
 ```
+
+## References
+
+1. [Turso Platform API](https://docs.turso.tech/api-reference/introduction)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,26 @@
+version: '3'
+
+tasks:
+  go:lint:
+    desc: runs golangci-lint, the most annoying opinionated linter ever
+    cmds:
+      - golangci-lint run -v
+
+  go:test:
+    desc: runs and outputs results of created go tests
+    cmds:
+      - go test -v ./...
+
+  go:tidy:
+    desc: runs go mod tidy
+    aliases: [tidy]
+    cmds:
+      - go mod tidy
+
+  go:all:
+    aliases: [go]
+    desc: runs all go test and lint related tasks
+    cmds:
+      - task: go:tidy
+      - task: go:lint
+      - task: go:test

--- a/client.go
+++ b/client.go
@@ -1,0 +1,85 @@
+package turso
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// Client manages communication with the Turso API
+type Client struct {
+	cfg    *Config
+	client HTTPRequestDoer
+
+	common service // Reuse a single struct instead of allocating one for each service on the heap.
+
+	// Services
+	Organization   organizationService
+	Group          groupService
+	Database       databaseService
+	DatabaseTokens databaseTokensService
+}
+
+type service struct {
+	client *Client
+}
+
+// HTTPRequestDoer implements the standard http.Client interface.
+type HTTPRequestDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client returns the http client
+func (c *Client) Client() HTTPRequestDoer {
+	return c.client
+}
+
+// NewClient creates a new client for interacting with the Turso API.
+func NewClient(c Config) (*Client, error) {
+	if c.Token == "" {
+		return nil, ErrAPITokenNotSet
+	}
+
+	client := &Client{
+		cfg: &c,
+	}
+
+	if client.client == nil {
+		client.client = http.DefaultClient
+	}
+
+	client.common.client = client
+
+	// initialize services
+	client.Organization = (*OrganizationService)(&client.common)
+	client.Database = (*DatabaseService)(&client.common)
+	client.Group = (*GroupService)(&client.common)
+	client.DatabaseTokens = (*DatabaseTokensService)(&client.common)
+
+	return client, nil
+}
+
+// DoRequest performs an HTTP request and returns the response
+func (c *Client) DoRequest(ctx context.Context, method string, url string, data interface{}) (*http.Response, error) {
+	var bodyReader io.Reader
+
+	buf, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyReader = bytes.NewReader(buf)
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add Headers
+	req.Header.Add("Authorization", "Bearer "+c.cfg.Token)
+	req.Header.Add("Content-Type", "application/json")
+
+	return c.client.Do(req.WithContext(ctx))
+}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,11 @@
+package turso
+
+// Config is the configuration for the turso client
+type Config struct {
+	// Token is the token used to authenticate with the turso API
+	Token string `json:"token" koanf:"token" jsonschema:"required"`
+	// BaseURL is the base URL for the turso API
+	BaseURL string `json:"base_url" koanf:"base_url" jsonschema:"required" default:"https://api.turso.tech"`
+	// OrgName is the name of the organization to use for the turso API
+	OrgName string `json:"org_name" koanf:"org_name" jsonschema:"required"`
+}

--- a/database.go
+++ b/database.go
@@ -1,0 +1,231 @@
+package turso
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+)
+
+const (
+	databaseEndpoint = "v1/organizations/%s/databases"
+	maxNameLength    = 32
+	regexName        = "^[a-z0-9-]+$"
+)
+
+// DatabaseService is the interface for the Turso API database endpoint
+type DatabaseService service
+
+type databaseService interface {
+	// ListDatabases lists all databases in the organization
+	ListDatabases(ctx context.Context) (*ListDatabaseResponse, error)
+	// CreateDatabase creates a new database
+	CreateDatabase(ctx context.Context, req CreateDatabaseRequest) (*CreateDatabaseResponse, error)
+	// GetDatabase gets a database by name
+	GetDatabase(ctx context.Context, dbName string) (*GetDatabaseResponse, error)
+	// DeleteDatabase deletes a database by name
+	DeleteDatabase(ctx context.Context, dbName string) (*DeleteDatabaseResponse, error)
+}
+
+// Database is the struct for the Turso Database object
+type Database struct {
+	// Name is the name of the database
+	Name string `json:"Name"`
+	// DatabaseID is the ID of the database
+	DatabaseID string `json:"DbId"`
+	// Hostname is the hostname of the database`
+	Hostname string `json:"Hostname"` // this is in the response twice, once with a capital H and once with a lowercase h
+	// IsSchema is this database controls other child databases then this will be true
+	IsSchema bool `json:"is_schema"`
+	// Schema is the name of the parent database that owns the schema for this database
+	Schema string `json:"schema"`
+	// BlockedReads is true if reads are blocked
+	BlockReads bool `json:"block_reads"`
+	// BlockedWrites is true if writes are blocked
+	BlockWrites bool `json:"block_writes"`
+	// AllowAttach is true if the database allows attachments of a child database
+	AllowAttach bool `json:"allow_attach"`
+	// Regions is a list of regions the database is available in
+	Regions []string `json:"regions"`
+	// PrimaryRegion is the primary region for the database
+	PrimaryRegion string `json:"primaryRegion"`
+	// Type is the type of the database
+	Type string `json:"type"`
+	// Version is the version of libsql used by the database
+	Version string `json:"version"`
+	// Group is the group the database is in
+	Group string `json:"group"`
+	// Sleeping is true if the database is sleeping
+	Sleeping bool `json:"sleeping"`
+}
+
+// ListDatabaseResponse is the struct for the Turso API database list response
+type ListDatabaseResponse struct {
+	Databases []*Database `json:"databases"`
+}
+
+// GetDatabaseResponse is the struct for the Turso API database get response
+type GetDatabaseResponse struct {
+	Database *Database `json:"database"`
+}
+
+// CreateDatabaseResponse is the struct for the Turso API database create response
+type CreateDatabaseResponse struct {
+	Database struct {
+		// DatabaseID is the ID of the database
+		DatabaseID string `json:"DbId"`
+		// Name is the name of the database
+		Name string `json:"Name"`
+		// Hostname is the hostname of the database
+		Hostname string `json:"Hostname"`
+		// IssuedCertCount is the number of certificates issued
+		IssuedCertCount int `json:"IssuedCertCount"`
+		// IssuedCertLimit is the limit of certificates that can be issued
+		IssuedCertLimit int `json:"IssuedCertLimit"`
+	} `json:"database"`
+}
+
+// DeleteDatabaseResponse is the struct for the Turso API database delete response
+type DeleteDatabaseResponse struct {
+	Database string `json:"database"`
+}
+
+// CreateDatabaseRequest is the struct for the Turso API database create request
+type CreateDatabaseRequest struct {
+	// Group is the group the database is in
+	Group string `json:"group"`
+	// IsSchema is this database controls other child databases then this will be true
+	IsSchema bool `json:"is_schema"`
+	// Name is the name of the database
+	// Must contain only lowercase letters, numbers, dashes. No longer than 32 characters.
+	Name string `json:"name"`
+}
+
+// getDatabaseEndpoint returns the endpoint for the Turso API database service
+func getDatabaseEndpoint(baseURL, orgName string) string {
+	dbEndpoint := fmt.Sprintf(databaseEndpoint, orgName)
+	return fmt.Sprintf("%s/%s", baseURL, dbEndpoint)
+}
+
+// CreateDatabase satisfies the databaseService interface
+func (s *DatabaseService) CreateDatabase(ctx context.Context, db CreateDatabaseRequest) (*CreateDatabaseResponse, error) {
+	// Sanitize the database name
+	if err := validateDatabaseName(db.Name); err != nil {
+		return nil, err
+	}
+
+	// Create the database
+	endpoint := getDatabaseEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodPost, endpoint, db)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	// Decode the response
+	var out CreateDatabaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("database", "creating", resp.StatusCode)
+	}
+
+	return &out, nil
+}
+
+// ListDatabases satisfies the databaseService interface
+func (s *DatabaseService) ListDatabases(ctx context.Context) (*ListDatabaseResponse, error) {
+	endpoint := getDatabaseEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var out ListDatabaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("databases", "listing", resp.StatusCode)
+	}
+
+	return &out, nil
+}
+
+// GetDatabase satisfies the databaseService interface
+func (s *DatabaseService) GetDatabase(ctx context.Context, dbName string) (*GetDatabaseResponse, error) {
+	// get endpoint and append the database name
+	endpoint := getDatabaseEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
+	endpoint = fmt.Sprintf("%s/%s", endpoint, dbName)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var out *GetDatabaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("database", "getting", resp.StatusCode)
+	}
+
+	return out, nil
+}
+
+// DeleteDatabase satisfies the databaseService interface
+func (s *DatabaseService) DeleteDatabase(ctx context.Context, dbName string) (*DeleteDatabaseResponse, error) {
+	// Delete the database
+	endpoint := getDatabaseEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
+	endpoint = fmt.Sprintf("%s/%s", endpoint, dbName)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	// Decode the response
+	var out DeleteDatabaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("database", "deleting", resp.StatusCode)
+	}
+
+	return &out, nil
+}
+
+// validateDatabaseName validates the database name to ensure it meets the requirements set by the Turso API
+func validateDatabaseName(name string) error {
+	match, err := regexp.MatchString(regexName, name)
+	if err != nil {
+		return err
+	}
+
+	if !match {
+		return ErrInvalidDatabaseName
+	}
+
+	if len(name) > maxNameLength {
+		return ErrInvalidDatabaseName
+	}
+
+	return nil
+}

--- a/database_test.go
+++ b/database_test.go
@@ -1,0 +1,138 @@
+package turso
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListDatabases(t *testing.T) {
+	body := `{"databases":[{"DbId":"0eb771dd-6906-11ee-8553-eaa7715aeaf2","Hostname":"[databaseName]-[organizationName].turso.io","Name":"my-db","allow_attach":true,"blocked_reads":true,"blocked_writes":true,"group":"default","is_schema":true,"primaryRegion":"lhr","regions":["lhr","bos","nrt"],"schema":"<string>","sleeping":true,"type":"logical","version":"0.22.22"}]}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	databaseService := DatabaseService{client: client}
+	resp, err := databaseService.ListDatabases(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, resp.Databases, 1)
+}
+func TestGetDatabase(t *testing.T) {
+	body := `{"database":{"DbId":"0eb771dd-6906-11ee-8553-eaa7715aeaf2","Hostname":"[databaseName]-[organizationName].turso.io","Name":"my-db","allow_attach":true,"blocked_reads":true,"blocked_writes":true,"group":"default","is_schema":true,"primaryRegion":"lhr","regions":["lhr","bos","nrt"],"schema":"<string>","sleeping":true,"type":"logical","version":"0.22.22"}}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	databaseService := DatabaseService{client: client}
+	resp, err := databaseService.GetDatabase(context.Background(), "my-db")
+	require.NoError(t, err)
+	assert.Equal(t, resp.Database.Name, "my-db")
+}
+
+func TestDeleteDatabase(t *testing.T) {
+	body := `{"database": "my-db"}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	databaseService := DatabaseService{client: client}
+	resp, err := databaseService.DeleteDatabase(context.Background(), "my-db")
+	require.NoError(t, err)
+	assert.Equal(t, resp.Database, "my-db")
+}
+
+func TestCreateDatabase(t *testing.T) {
+	body := `{"database":{"DbId":"0eb771dd-6906-11ee-8553-eaa7715aeaf2","Hostname":"[databaseName]-[organizationName].turso.io","Name":"my-db"}}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	// happy path
+	databaseService := DatabaseService{client: client}
+	req := CreateDatabaseRequest{
+		Name: "my-db",
+	}
+
+	resp, err := databaseService.CreateDatabase(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, resp.Database.Name, "my-db")
+
+	// test error
+	req = CreateDatabaseRequest{
+		Name: "myAWESOMEdb",
+	}
+
+	resp, err = databaseService.CreateDatabase(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestValidateDatabaseName(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expectErr bool
+	}{
+		{
+			name:      "happy path, simple name",
+			input:     "mydatabase-123",
+			expectErr: false,
+		},
+		{
+			name:      "name with uppercase",
+			input:     "ORG-123ABC",
+			expectErr: true,
+		},
+		{
+			name:      "long name",
+			input:     "MECPJTpHtBEyUNBAujXw6mxCjN4ARLPJ3",
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		result := validateDatabaseName(test.input)
+		if test.expectErr {
+			require.Error(t, result)
+		} else {
+			require.NoError(t, result)
+		}
+	}
+}

--- a/database_tokens.go
+++ b/database_tokens.go
@@ -1,0 +1,139 @@
+package turso
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/xhit/go-str2duration/v2"
+)
+
+const (
+	databaseTokensEndpoint = "v1/organizations/%s/databases/%s/auth/tokens"
+	FullAccess             = "full-access"
+	ReadOnly               = "read-only"
+	DefaultExpiration      = "never"
+)
+
+var validAuthorization = []string{FullAccess, ReadOnly}
+
+// DatabaseTokensService is the interface for the Turso API database tokens service
+type DatabaseTokensService service
+
+type databaseTokensService interface {
+	// CreateDatabaseToken creates a new database token
+	CreateDatabaseToken(ctx context.Context, req CreateDatabaseTokenRequest) (*CreateDatabaseTokenResponse, error)
+}
+
+// CreateDatabaseTokenRequest is the struct for the Turso API database token create request
+type CreateDatabaseTokenRequest struct {
+	// DatabaseName is the name of the database
+	DatabaseName string
+	// Expiration is the expiration time for the token
+	Expiration string
+	// Permissions is the permissions for the token
+	Authorization string
+	// ReadAttach permission for the token
+	AttachPermissions Permissions `json:"permissions"`
+}
+
+type Permissions struct {
+	ReadAttach struct {
+		Database []string `json:"database"`
+	} `json:"read_attach"`
+}
+
+// CreateDatabaseTokenResponse is the struct for the Turso API database token create response
+type CreateDatabaseTokenResponse struct {
+	JWT string `json:"jwt"`
+}
+
+// InvalidateDatabaseTokenRequest is the struct for the Turso API database token invalidate request
+type InvalidateDatabaseTokenRequest struct {
+	// DatabaseName is the name of the database
+	DatabaseName string `json:"database_name"`
+}
+
+// getDatabaseTokensEndpoint returns the endpoint for the Turso API database token service
+func getDatabaseTokensEndpoint(baseURL, orgName, dbName string) string {
+	dbEndpoint := fmt.Sprintf(databaseTokensEndpoint, orgName, dbName)
+	return fmt.Sprintf("%s/%s", baseURL, dbEndpoint)
+}
+
+// CreateDatabaseToken satisfies the databaseTokensService interface
+func (s *DatabaseTokensService) CreateDatabaseToken(ctx context.Context, req CreateDatabaseTokenRequest) (*CreateDatabaseTokenResponse, error) {
+	if err := validateDatabaseTokenRequest(req); err != nil {
+		return nil, err
+	}
+
+	endpoint := getDatabaseTokensEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName, req.DatabaseName)
+	endpoint = fmt.Sprintf("%s?expiration=%s&authorization=%s", endpoint, req.Expiration, req.Authorization)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodPost, endpoint, req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var out CreateDatabaseTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("database token", "creating", resp.StatusCode)
+	}
+
+	return &out, nil
+}
+
+// validateDatabaseTokenRequest ensures the authorization and expiration are valid
+// in the given request before making the API call
+func validateDatabaseTokenRequest(req CreateDatabaseTokenRequest) error {
+	if !isValidExpiration(req.Expiration) {
+		return ErrExpirationInvalid
+	}
+
+	if !isValidAuthorization(req.Authorization) {
+		return ErrAuthorizationInvalid
+	}
+
+	return nil
+}
+
+// IsValidExpiration checks if the expiration is valid
+func isValidExpiration(expiration string) bool {
+	// check for empty fields first
+	if expiration == "" {
+		return false
+	}
+
+	if expiration == DefaultExpiration {
+		return true
+	}
+
+	if _, err := str2duration.ParseDuration(expiration); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// IsValidAuthorization checks if the authorization is valid
+func isValidAuthorization(authorization string) bool {
+	// check for empty fields first
+	if authorization == "" {
+		return false
+	}
+
+	// check for valid authorization
+	for _, v := range validAuthorization {
+		if v == authorization {
+			return true
+		}
+	}
+
+	return false
+}

--- a/database_tokens_test.go
+++ b/database_tokens_test.go
@@ -1,0 +1,130 @@
+package turso
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateDatabaseToken(t *testing.T) {
+	body := `{"jwt": "areallylongstringjwtgoeshere"}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	// happy path
+	databaseTokenService := DatabaseTokensService{client: client}
+	req := CreateDatabaseTokenRequest{
+		DatabaseName:  "my-db",
+		Expiration:    "1h30m",
+		Authorization: FullAccess,
+	}
+
+	resp, err := databaseTokenService.CreateDatabaseToken(context.Background(), req)
+	require.NoError(t, err)
+	assert.NotNil(t, resp.JWT)
+
+	// test errors
+	req = CreateDatabaseTokenRequest{
+		DatabaseName:  "my-db",
+		Authorization: FullAccess,
+	}
+
+	resp, err = databaseTokenService.CreateDatabaseToken(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	req = CreateDatabaseTokenRequest{
+		DatabaseName:  "my-db",
+		Expiration:    "1h30m",
+		Authorization: "invalid",
+	}
+
+	resp, err = databaseTokenService.CreateDatabaseToken(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestValidateDatabaseTokenRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		request CreateDatabaseTokenRequest
+		wantErr error
+	}{
+		{
+			name: "Valid request, full access",
+			request: CreateDatabaseTokenRequest{
+				Expiration:    "never",
+				Authorization: "full-access",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Valid request, read only",
+			request: CreateDatabaseTokenRequest{
+				Expiration:    "never",
+				Authorization: "read-only",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Valid request, with duration",
+			request: CreateDatabaseTokenRequest{
+				Expiration:    "12w",
+				Authorization: "read-only",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Missing expiration",
+			request: CreateDatabaseTokenRequest{
+				Expiration:    "",
+				Authorization: "read-only",
+			},
+			wantErr: ErrExpirationInvalid,
+		},
+		{
+			name: "Invalid authorization",
+			request: CreateDatabaseTokenRequest{
+				Expiration:    "never",
+				Authorization: "invalid",
+			},
+			wantErr: ErrAuthorizationInvalid,
+		},
+		{
+			name: "Invalid expiration",
+			request: CreateDatabaseTokenRequest{
+				Expiration:    "2030-01-01",
+				Authorization: "invalid",
+			},
+			wantErr: ErrExpirationInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDatabaseTokenRequest(tt.request)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Package turso provides a client for interacting with the Turso API.
+package turso

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,44 @@
+package turso
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrAPITokenNotSet is returned when the API token is not set
+	ErrAPITokenNotSet = errors.New("api token not set, but required")
+
+	// ErrInvalidDatabaseName is returned when a database name is invalid
+	ErrInvalidDatabaseName = errors.New("invalid database name, can only contain lowercase letters, numbers, dashes with a maximum of 32 characters")
+
+	// ErrExpirationNotSet is returned when the expiration is not set
+	ErrExpirationInvalid = errors.New("expiration invalid, must be a valid duration (e.g. 12w) or never")
+
+	// ErrAuthorizationInvalid is returned when the authorization is invalid
+	ErrAuthorizationInvalid = errors.New("authorization invalid, valid options are full-access or read-only")
+)
+
+// TursoError is returned when a request to the Turso API fails
+type TursoError struct {
+	// Object is the object that the error occurred on
+	Object string
+	// Method is the method that the error occurred in
+	Method string
+	// Status is the status code of the error
+	Status int
+}
+
+// Error returns the RequiredFieldMissingError in string format
+func (e *TursoError) Error() string {
+	return fmt.Sprintf("error %s %s: %d", e.Method, e.Object, e.Status)
+}
+
+// newBadRequestError returns an error a bad request
+func newBadRequestError(object, method string, status int) *TursoError {
+	return &TursoError{
+		Object: object,
+		Method: method,
+		Status: status,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/datumforge/go-turso
+
+go 1.22.1
+
+require (
+	github.com/stretchr/testify v1.9.0
+	github.com/xhit/go-str2duration/v2 v2.1.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/group.go
+++ b/group.go
@@ -1,0 +1,168 @@
+package turso
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	groupEndpoint = "v1/organizations/%s/groups"
+)
+
+// GroupService is the interface for the Turso API group endpoint
+type GroupService service
+
+type groupService interface {
+	// ListGroups lists all groups in the organization
+	ListGroups(ctx context.Context) (*ListGroupResponse, error)
+	// CreateGroup creates a new group in the organization
+	CreateGroup(ctx context.Context, req GroupCreateRequest) (*CreateGroupResponse, error)
+	// GetGroup gets a group by name
+	GetGroup(ctx context.Context, groupName string) (*GetGroupResponse, error)
+	// DeleteGroup deletes a group by name
+	DeleteGroup(ctx context.Context, groupName string) (*DeleteGroupResponse, error)
+}
+
+// Group is the struct for the Turso API group service
+type Group struct {
+	Archived  bool     `json:"archived"`
+	Locations []string `json:"locations"`
+	Name      string   `json:"name"`
+	Primary   string   `json:"primary"`
+	UUID      string   `json:"uuid"`
+	Version   string   `json:"version"`
+}
+
+// ListGroupResponse is the struct for the Turso API group list response
+type ListGroupResponse struct {
+	Groups []Group `json:"groups"`
+}
+
+// GetGroupResponse is the struct for the Turso API group get response
+type GetGroupResponse struct {
+	Group Group `json:"group"`
+}
+
+// CreateGroupResponse is the struct for the Turso API group create response
+type CreateGroupResponse struct {
+	Group Group `json:"group"`
+}
+
+// DeleteGroupResponse is the struct for the Turso API group delete response
+type DeleteGroupResponse struct {
+	Group Group `json:"group"`
+}
+
+// GroupCreateRequest is the struct for the Turso API group create request
+type GroupCreateRequest struct {
+	Extensions string `json:"extensions"`
+	Location   string `json:"location"`
+	Name       string `json:"name"`
+}
+
+// getGroupEndpoint returns the endpoint for the Turso API group service
+func getGroupEndpoint(baseURL, orgName string) string {
+	dbEndpoint := fmt.Sprintf(groupEndpoint, orgName)
+	return fmt.Sprintf("%s/%s", baseURL, dbEndpoint)
+}
+
+// ListGroups satisfies the groupService interface
+func (s *GroupService) ListGroups(ctx context.Context) (*ListGroupResponse, error) {
+	endpoint := getGroupEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var out ListGroupResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("groups", "listing", resp.StatusCode)
+	}
+
+	return &out, nil
+}
+
+// CreateGroup satisfies the groupService interface
+func (s *GroupService) CreateGroup(ctx context.Context, group GroupCreateRequest) (*CreateGroupResponse, error) {
+	// Create the group
+	endpoint := getGroupEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodPost, endpoint, group)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	// Decode the response
+	var out CreateGroupResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("group", "creating", resp.StatusCode)
+	}
+
+	return &out, nil
+}
+
+// GetGroup satisfies the groupService interface
+func (s *GroupService) GetGroup(ctx context.Context, groupName string) (*GetGroupResponse, error) {
+	// get endpoint and append the group name
+	endpoint := getGroupEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
+	endpoint = fmt.Sprintf("%s/%s", endpoint, groupName)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var out *GetGroupResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("group", "getting", resp.StatusCode)
+	}
+
+	return out, nil
+}
+
+// DeleteGroup satisfies the groupService interface
+func (s *GroupService) DeleteGroup(ctx context.Context, groupName string) (*DeleteGroupResponse, error) {
+	// Create the group
+	endpoint := getGroupEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
+	endpoint = fmt.Sprintf("%s/%s", endpoint, groupName)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	// Decode the response
+	var out DeleteGroupResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("group", "deleting", resp.StatusCode)
+	}
+
+	return &out, nil
+}

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,104 @@
+package turso
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListGroups(t *testing.T) {
+	body := `{"groups":[{"archived":true,"locations":["lhr","ams","bos"],"name":"default","primary":"lhr","uuid":"0a28102d-6906-11ee-8553-eaa7715aeaf2","version":"v0.23.7"}]}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	groupService := GroupService{client: client}
+	resp, err := groupService.ListGroups(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, resp.Groups, 1)
+}
+func TestGetGroup(t *testing.T) {
+	body := `{"group":{"archived":true,"locations":["lhr","ams","bos"],"name":"meow","primary":"lhr","uuid":"0a28102d-6906-11ee-8553-eaa7715aeaf2","version":"v0.23.7"}}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	groupService := GroupService{client: client}
+	resp, err := groupService.GetGroup(context.Background(), "meow")
+	require.NoError(t, err)
+	assert.Equal(t, resp.Group.Name, "meow")
+}
+
+func TestDeleteGroup(t *testing.T) {
+	body := `{"group":{"archived":true,"locations":["lhr","ams","bos"],"name":"meow","primary":"lhr","uuid":"0a28102d-6906-11ee-8553-eaa7715aeaf2","version":"v0.23.7"}}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	groupService := GroupService{client: client}
+	resp, err := groupService.DeleteGroup(context.Background(), "meow")
+	require.NoError(t, err)
+	assert.Equal(t, resp.Group.Name, "meow")
+	assert.True(t, resp.Group.Archived)
+}
+
+func TestCreateGroup(t *testing.T) {
+	body := `{"group":{"archived":false,"locations":["lhr","ams","bos"],"name":"meow","primary":"lhr","uuid":"0a28102d-6906-11ee-8553-eaa7715aeaf2","version":"v0.23.7"}}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	// happy path
+	groupService := GroupService{client: client}
+	req := GroupCreateRequest{
+		Name: "meow",
+	}
+
+	resp, err := groupService.CreateGroup(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, resp.Group.Name, "meow")
+
+	// test error
+	req = GroupCreateRequest{}
+
+	resp, err = groupService.CreateGroup(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/organization.go
+++ b/organization.go
@@ -1,0 +1,60 @@
+package turso
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	organizationEndpoint = "v1/organizations"
+)
+
+type OrganizationService service
+
+type organizationService interface {
+	// ListOrganizations lists all organizations for the authorized user
+	ListOrganizations(ctx context.Context) (*[]Organization, error)
+}
+
+// Organization is the struct for the Turso Organization object
+type Organization struct {
+	Name          string `json:"name"`
+	Slug          string `json:"slug"`
+	Type          string `json:"type"`
+	PlanID        string `json:"plan_id"`
+	Overages      bool   `json:"overages"`
+	BlockedReads  bool   `json:"blocked_reads"`
+	BlockedWrites bool   `json:"blocked_writes"`
+	PlanTimeline  string `json:"plan_timeline"`
+	Memory        int    `json:"memory"`
+}
+
+// getOrganizationEndpoint returns the endpoint for the Turso API organization service
+func getOrganizationEndpoint(baseURL string) string {
+	return fmt.Sprintf("%s/%s", baseURL, organizationEndpoint)
+}
+
+// ListOrganizations satisfies the organizationService interface
+func (s *OrganizationService) ListOrganizations(ctx context.Context) (*[]Organization, error) {
+	endpoint := getOrganizationEndpoint(s.client.cfg.BaseURL)
+
+	resp, err := s.client.DoRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var out []Organization
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newBadRequestError("organizations", "listing", resp.StatusCode)
+	}
+
+	return &out, nil
+}

--- a/organization_test.go
+++ b/organization_test.go
@@ -1,0 +1,32 @@
+package turso
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListOrganizations(t *testing.T) {
+	body := `[{"name":"personal","slug":"moewlemonade","type":"personal","plan_id":"starter","overages":false,"blocked_reads":false,"blocked_writes":false,"plan_timeline":"","memory":0},{"name":"meow","slug":"meow","type":"team","plan_id":"scaler","overages":false,"blocked_reads":false,"blocked_writes":false,"plan_timeline":"monthly","memory":0}]`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	orgService := OrganizationService{client: client}
+	resp, err := orgService.ListOrganizations(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, *resp, 2)
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,8 @@
+{
+    "extends": [
+        "config:base"
+    ],
+    "postUpdateOptions": [
+        "gomodTidy"
+    ]
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=datumforge_go-turso
+sonar.organization=datumforge
+
+sonar.projectName=go-turso
+sonar.projectVersion=1.0
+
+sonar.sources=.
+
+sonar.exclusions=
+sonar.tests=.
+sonar.test.inclusions=*_test.go
+sonar.exclusions=
+
+sonar.sourceEncoding=UTF-8
+sonar.go.coverage.reportPaths=coverage.out
+sonar.externalIssuesReportPaths=results.txt

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,0 +1,14 @@
+package turso
+
+import "net/http"
+
+// MockHTTPRequestDoer implements the standard http.Client interface.
+type MockHTTPRequestDoer struct {
+	Response *http.Response
+	Error    error
+}
+
+// Do implements the standard http.Client interface for MockHTTPRequestDoer
+func (md *MockHTTPRequestDoer) Do(req *http.Request) (*http.Response, error) {
+	return md.Response, md.Error
+}


### PR DESCRIPTION
- sets up basic client struct
- adds CRUD operations for groups, databases, and list Organizations, create db tokens
- validates database name and returns error if doesn't match pattern required
- test coverage for basic functionality
- examples in README
- CI pipeline
- adds renovate config