### PR TITLE
Update Group service, add/remove location, fix naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently supports the following endpoints:
 1. `Organizations`: `List`
 1. `Groups`: `List`, `Get`, `Create`, `Delete`
 1. `Databases`: `List`, `Get`, `Create`, `Delete`
+1. `Database Locations`: `Add`, `Remove`
 1. `Database Tokens`: `Create`
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ func main() {
 	}
 
 	// Create a new Group
-	g := turso.GroupCreateRequest{
+	g := turso.CreateGroupRequest{
 		Name:     "test-group",
 		Location: "ord",
 	}

--- a/config.go
+++ b/config.go
@@ -5,7 +5,7 @@ type Config struct {
 	// Token is the token used to authenticate with the turso API
 	Token string `json:"token" koanf:"token" jsonschema:"required"`
 	// BaseURL is the base URL for the turso API
-	BaseURL string `json:"base_url" koanf:"base_url" jsonschema:"required" default:"https://api.turso.tech"`
+	BaseURL string `json:"baseUrl" koanf:"baseUrl" jsonschema:"required" default:"https://api.turso.tech"`
 	// OrgName is the name of the organization to use for the turso API
-	OrgName string `json:"org_name" koanf:"org_name" jsonschema:"required"`
+	OrgName string `json:"orgName" koanf:"orgName" jsonschema:"required"`
 }

--- a/errors.go
+++ b/errors.go
@@ -49,7 +49,7 @@ type MissingRequiredFieldError struct {
 	RequiredField string
 }
 
-// Error returns the InvalidEmailConfigError in string format
+// Error returns the MissingRequiredFieldError in string format
 func (e *MissingRequiredFieldError) Error() string {
 	return fmt.Sprintf("%s is required", e.RequiredField)
 }

--- a/errors.go
+++ b/errors.go
@@ -42,3 +42,21 @@ func newBadRequestError(object, method string, status int) *TursoError {
 		Status: status,
 	}
 }
+
+// MissingRequiredFieldError is returned when a required field was not provided in a request
+type MissingRequiredFieldError struct {
+	// RequiredField that is missing
+	RequiredField string
+}
+
+// Error returns the InvalidEmailConfigError in string format
+func (e *MissingRequiredFieldError) Error() string {
+	return fmt.Sprintf("%s is required", e.RequiredField)
+}
+
+// newMissingRequiredField returns an error for a missing required field
+func newMissingRequiredFieldError(field string) *MissingRequiredFieldError {
+	return &MissingRequiredFieldError{
+		RequiredField: field,
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -60,3 +60,22 @@ func newMissingRequiredFieldError(field string) *MissingRequiredFieldError {
 		RequiredField: field,
 	}
 }
+
+// InvalidFieldError is returned when a required field does not meet the required criteria
+type InvalidFieldError struct {
+	Field   string
+	Message string
+}
+
+// Error returns the InvalidFieldError in string format
+func (e *InvalidFieldError) Error() string {
+	return fmt.Sprintf("%s is invalid, %s", e.Field, e.Message)
+}
+
+// newMissingRequiredField returns an error for a missing required field
+func newInvalidFieldError(field, message string) *InvalidFieldError {
+	return &InvalidFieldError{
+		Field:   field,
+		Message: message,
+	}
+}

--- a/group.go
+++ b/group.go
@@ -26,7 +26,7 @@ type groupService interface {
 	DeleteGroup(ctx context.Context, groupName string) (*DeleteGroupResponse, error)
 	// AddLocation adds a location to a group
 	AddLocation(ctx context.Context, eq GroupLocationRequest) (*GroupLocationResponse, error)
-	// RemoveLocation adds a location to a group
+	// RemoveLocation removes a location from a group
 	RemoveLocation(ctx context.Context, req GroupLocationRequest) (*GroupLocationResponse, error)
 }
 
@@ -55,7 +55,7 @@ type CreateGroupResponse struct {
 	Group Group `json:"group"`
 }
 
-// GroupLocationRequest is the struct for the Turso API add location to group request
+// GroupLocationRequest is the struct for the Turso API to add or remove a location to a group request
 type GroupLocationRequest struct {
 	// GroupName is the name of the group to add the location
 	GroupName string
@@ -63,7 +63,7 @@ type GroupLocationRequest struct {
 	Location string
 }
 
-// GroupLocationResponse is the struct for the Turso API add location to group response
+// GroupLocationResponse is the struct for the Turso API to add or remove location to group response
 type GroupLocationResponse struct {
 	Group Group `json:"group"`
 }

--- a/group.go
+++ b/group.go
@@ -18,7 +18,7 @@ type groupService interface {
 	// ListGroups lists all groups in the organization
 	ListGroups(ctx context.Context) (*ListGroupResponse, error)
 	// CreateGroup creates a new group in the organization
-	CreateGroup(ctx context.Context, req GroupCreateRequest) (*CreateGroupResponse, error)
+	CreateGroup(ctx context.Context, req CreateGroupRequest) (*CreateGroupResponse, error)
 	// GetGroup gets a group by name
 	GetGroup(ctx context.Context, groupName string) (*GetGroupResponse, error)
 	// DeleteGroup deletes a group by name
@@ -55,8 +55,8 @@ type DeleteGroupResponse struct {
 	Group Group `json:"group"`
 }
 
-// GroupCreateRequest is the struct for the Turso API group create request
-type GroupCreateRequest struct {
+// CreateGroupRequest is the struct for the Turso API group create request
+type CreateGroupRequest struct {
 	Extensions string `json:"extensions"`
 	Location   string `json:"location"`
 	Name       string `json:"name"`
@@ -92,7 +92,7 @@ func (s *GroupService) ListGroups(ctx context.Context) (*ListGroupResponse, erro
 }
 
 // CreateGroup satisfies the groupService interface
-func (s *GroupService) CreateGroup(ctx context.Context, group GroupCreateRequest) (*CreateGroupResponse, error) {
+func (s *GroupService) CreateGroup(ctx context.Context, group CreateGroupRequest) (*CreateGroupResponse, error) {
 	// Create the group
 	endpoint := getGroupEndpoint(s.client.cfg.BaseURL, s.client.cfg.OrgName)
 

--- a/group_test.go
+++ b/group_test.go
@@ -102,3 +102,91 @@ func TestCreateGroup(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 }
+
+func TestAddLocation(t *testing.T) {
+	body := `{"group":{"archived":false,"locations":["lhr","ams","bos", "den"],"name":"meow","primary":"lhr","uuid":"0a28102d-6906-11ee-8553-eaa7715aeaf2","version":"v0.23.7"}}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	// happy path
+	groupService := GroupService{client: client}
+	req := GroupLocationRequest{
+		GroupName: "meow",
+		Location:  "den",
+	}
+
+	resp, err := groupService.AddLocation(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, resp.Group.Name, "meow")
+
+	// test error, missing location
+	req = GroupLocationRequest{
+		GroupName: "meow",
+	}
+
+	resp, err = groupService.AddLocation(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	// test error, missing group name
+	req = GroupLocationRequest{
+		Location: "den",
+	}
+
+	resp, err = groupService.AddLocation(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestRemoveLocation(t *testing.T) {
+	body := `{"group":{"archived":false,"locations":["lhr","ams","bos"] ,"name":"meow","primary":"lhr","uuid":"0a28102d-6906-11ee-8553-eaa7715aeaf2","version":"v0.23.7"}}`
+	client := &Client{
+		cfg: &Config{
+			BaseURL: "http://localhost",
+		},
+		client: &MockHTTPRequestDoer{
+			Response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+			},
+		},
+	}
+
+	// happy path
+	groupService := GroupService{client: client}
+	req := GroupLocationRequest{
+		GroupName: "meow",
+		Location:  "den",
+	}
+
+	resp, err := groupService.RemoveLocation(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, resp.Group.Name, "meow")
+
+	// test error, missing location
+	req = GroupLocationRequest{
+		GroupName: "meow",
+	}
+
+	resp, err = groupService.RemoveLocation(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	// test error, missing group name
+	req = GroupLocationRequest{
+		Location: "den",
+	}
+
+	resp, err = groupService.RemoveLocation(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/group_test.go
+++ b/group_test.go
@@ -87,7 +87,7 @@ func TestCreateGroup(t *testing.T) {
 
 	// happy path
 	groupService := GroupService{client: client}
-	req := GroupCreateRequest{
+	req := CreateGroupRequest{
 		Name: "meow",
 	}
 
@@ -96,7 +96,7 @@ func TestCreateGroup(t *testing.T) {
 	assert.Equal(t, resp.Group.Name, "meow")
 
 	// test error
-	req = GroupCreateRequest{}
+	req = CreateGroupRequest{}
 
 	resp, err = groupService.CreateGroup(context.Background(), req)
 	assert.Error(t, err)


### PR DESCRIPTION
- fix inconsistent naming, renames GroupCreateRequest to CreateGroupRequest to follow the same pattern on all things, `<Action><Object><Type>`
- Adds a `AddLocation` and `RemoveLocation` for the GroupService
- Adds basic validation to group requests
- Fixes struct tags to be camelCase instead of snake_case